### PR TITLE
fix: Votes - Only list votes related to the specified question

### DIFF
--- a/app/controllers/api/v1/votes_controller.rb
+++ b/app/controllers/api/v1/votes_controller.rb
@@ -6,7 +6,7 @@ module Api
       before_action :find_answer, only: %i[create update]
 
       def index
-        @votes = Vote.all
+        @votes = Vote.on_question(params[:id])
       end
 
       def create

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -15,6 +15,8 @@ class Vote < ApplicationRecord
 
   validates_with VoteValidator
 
+  scope :on_question, ->(question) { joins(answer: :question).where(answers: { question: question }) }
+
   def other_votes
     Vote.where.not(id: id)
   end

--- a/spec/models/vote_spec.rb
+++ b/spec/models/vote_spec.rb
@@ -40,4 +40,17 @@ RSpec.describe Vote, type: :model do
       end
     end
   end
+
+  describe '.on_question' do
+    subject(:vote_on_question) { described_class.on_question(question) }
+
+    let!(:question) { create :question }
+    let!(:answer_of_question) { create :answer, question: question }
+    let!(:vote_on_answer_of_question) { create :vote, answer: answer_of_question }
+    let!(:vote_on_other_question) { create :vote }
+
+    it 'only returns the vote related to the given question' do
+      expect(vote_on_question).to eq([vote_on_answer_of_question])
+    end
+  end
 end

--- a/spec/requests/api/v1/votes_request_spec.rb
+++ b/spec/requests/api/v1/votes_request_spec.rb
@@ -7,6 +7,7 @@ describe 'Votes', type: :request do
     let(:question) { create :question }
     let(:answer) { create :answer, question: question }
     let!(:vote) { create :vote, answer: answer }
+    let!(:vote_of_other_question) { create :vote }
 
     before do
       get "/api/v1/questions/#{question.id}/votes", headers: headers_of_logged_in_user


### PR DESCRIPTION
GET /question/:id/votes was listing all the votes instead of those relevant for a specific question.
This PR corrects this behaviour.